### PR TITLE
Fix header to revert to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,10 +13,6 @@
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <button 
                     id="themeToggle" 
                     class="theme-toggle"

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -70,7 +70,6 @@ body {
 /* Header */
 header {
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     padding: 1rem 1.5rem;
     flex-shrink: 0;
     transition: all 0.3s ease;
@@ -78,30 +77,11 @@ header {
 
 .header-content {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     max-width: 100%;
 }
 
-.header-text {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {


### PR DESCRIPTION
Reverts the header to the older version as requested in issue #2.

## Changes:
- Remove "Course Materials Assistant" header title
- Remove "Ask Questions About Courses, Instructors, and Content" subtitle
- Remove horizontal border below header
- Preserve theme toggle functionality positioned on the right
- Clean up unused CSS for removed header elements

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)